### PR TITLE
Trigger session-storage-set! when binding is deleted

### DIFF
--- a/http-session.scm
+++ b/http-session.scm
@@ -149,7 +149,8 @@
   (let ((sitem (get-session-item sid)))
     (session-item-bindings-set!
      sitem
-     (alist-delete! var (session-item-bindings sitem)))))
+     (alist-delete! var (session-item-bindings sitem)))
+    ((session-storage-set!) sid sitem)))
 
 (define (session-cleanup!)
   ((session-storage-cleanup!)))


### PR DESCRIPTION
This triggers the backend's `session-storage-set!` when a session item
binding is deleted with `session-del!`, to match the behaviour of
`session-set!`.
